### PR TITLE
Stage 3: implement local save/load and screenshot-ready lodge loop

### DIFF
--- a/src/game/scenes/UIScene.ts
+++ b/src/game/scenes/UIScene.ts
@@ -23,9 +23,11 @@ type BuildState = {
 };
 
 export class UIScene extends Phaser.Scene {
+  private hudContainer!: Phaser.GameObjects.Container;
   private inventoryText!: Phaser.GameObjects.Text;
   private modeText!: Phaser.GameObjects.Text;
   private buildText!: Phaser.GameObjects.Text;
+  private feedbackText!: Phaser.GameObjects.Text;
 
   constructor() {
     super('UIScene');
@@ -35,10 +37,14 @@ export class UIScene extends Phaser.Scene {
     this.createHud();
     this.game.events.on('inventory:changed', this.updateInventory, this);
     this.game.events.on('build:changed', this.updateBuildState, this);
+    this.game.events.on('hud:visibility-changed', this.updateHudVisibility, this);
+    this.game.events.on('hud:feedback', this.showFeedback, this);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.game.events.off('inventory:changed', this.updateInventory, this);
       this.game.events.off('build:changed', this.updateBuildState, this);
+      this.game.events.off('hud:visibility-changed', this.updateHudVisibility, this);
+      this.game.events.off('hud:feedback', this.showFeedback, this);
     });
   }
 
@@ -48,7 +54,7 @@ export class UIScene extends Phaser.Scene {
       .setScrollFactor(0)
       .setStrokeStyle(2, 0x6e4a2f, 0.95);
 
-    this.add.text(panel.x + 18, panel.y + 14, 'FJORDHOLD', {
+    const titleText = this.add.text(panel.x + 18, panel.y + 14, 'FJORDHOLD', {
       fontFamily: 'serif',
       fontSize: '22px',
       color: '#f4d18a',
@@ -56,7 +62,7 @@ export class UIScene extends Phaser.Scene {
       strokeThickness: 4
     }).setScrollFactor(0);
 
-    this.add.text(panel.x + 18, panel.y + 48, 'WASD / arrows: move  •  E / click: harvest  •  B: build  •  X: delete mode', {
+    const controlsText = this.add.text(panel.x + 18, panel.y + 48, 'WASD / arrows: move  •  E / click: harvest  •  B: build  •  X: delete mode', {
       fontFamily: 'monospace',
       fontSize: '13px',
       color: '#b7c8d6'
@@ -80,6 +86,29 @@ export class UIScene extends Phaser.Scene {
       color: '#90aebf',
       wordWrap: { width: 572 }
     }).setScrollFactor(0);
+
+    const utilityText = this.add.text(panel.x + 18, panel.y + 168, 'J: save  •  K: load  •  R: reset save (double-press)  •  H: hide HUD', {
+      fontFamily: 'monospace',
+      fontSize: '12px',
+      color: '#8ba4b6'
+    }).setScrollFactor(0);
+
+    this.feedbackText = this.add.text(panel.x + 18, panel.y + 194, '', {
+      fontFamily: 'monospace',
+      fontSize: '12px',
+      color: '#8bd3ff'
+    }).setScrollFactor(0);
+
+    this.hudContainer = this.add.container(0, 0, [
+      panel,
+      titleText,
+      controlsText,
+      this.modeText,
+      this.inventoryText,
+      this.buildText,
+      utilityText,
+      this.feedbackText
+    ]);
   }
 
   private updateInventory(inventory: InventoryCounts): void {
@@ -118,5 +147,23 @@ export class UIScene extends Phaser.Scene {
   private formatItemName(item: string): string {
     if (item === 'ironOre') return 'iron';
     return item;
+  }
+
+  private updateHudVisibility(visible: boolean): void {
+    this.hudContainer.setVisible(visible);
+  }
+
+  private showFeedback(payload: { message: string; color: string }): void {
+    this.feedbackText.setText(payload.message);
+    this.feedbackText.setColor(payload.color);
+
+    this.tweens.killTweensOf(this.feedbackText);
+    this.feedbackText.setAlpha(1);
+    this.tweens.add({
+      targets: this.feedbackText,
+      alpha: 0.65,
+      duration: 1600,
+      ease: 'Quad.easeOut'
+    });
   }
 }

--- a/src/game/scenes/WorldScene.ts
+++ b/src/game/scenes/WorldScene.ts
@@ -6,6 +6,8 @@ const WORLD_HEIGHT = 1600;
 const PLAYER_SPEED = 220;
 const HARVEST_RANGE = 105;
 const BUILD_GRID_SIZE = 64;
+const SAVE_STORAGE_KEY = 'fjordhold_stage3_save';
+const RESET_CONFIRM_WINDOW_MS = 3000;
 
 type ResourceKind = 'tree' | 'rock' | 'ore';
 type InventoryItem = 'wood' | 'stone' | 'ironOre' | 'resin';
@@ -46,6 +48,19 @@ type PlacedBuildPiece = {
   flame?: Phaser.GameObjects.Triangle;
 };
 
+type SavedPlacedPiece = {
+  pieceId: BuildPieceId;
+  gridX: number;
+  gridY: number;
+};
+
+type SaveData = {
+  version: 1;
+  inventory: InventoryCounts;
+  placedPieces: SavedPlacedPiece[];
+  savedAt: string;
+};
+
 type InputKeys = {
   W: Phaser.Input.Keyboard.Key;
   A: Phaser.Input.Keyboard.Key;
@@ -61,6 +76,10 @@ type InputKeys = {
   FIVE: Phaser.Input.Keyboard.Key;
   SIX: Phaser.Input.Keyboard.Key;
   X: Phaser.Input.Keyboard.Key;
+  H: Phaser.Input.Keyboard.Key;
+  J: Phaser.Input.Keyboard.Key;
+  K: Phaser.Input.Keyboard.Key;
+  R: Phaser.Input.Keyboard.Key;
 };
 
 const RESOURCE_DEFINITIONS: Record<ResourceKind, { health: number; item: InventoryItem; label: string }> = {
@@ -129,17 +148,19 @@ const BUILD_TEXTURE_KEYS: Record<BuildPieceId, string> = {
   woodDoor: 'build_wood_door'
 };
 
+const DEFAULT_INVENTORY: InventoryCounts = {
+  wood: 8,
+  stone: 4,
+  ironOre: 0,
+  resin: 2
+};
+
 export class WorldScene extends Phaser.Scene {
   private player!: Phaser.GameObjects.Container;
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private keys!: InputKeys;
   private resourceNodes: ResourceNode[] = [];
-  private inventory: InventoryCounts = {
-    wood: 8,
-    stone: 4,
-    ironOre: 0,
-    resin: 2
-  };
+  private inventory: InventoryCounts = { ...DEFAULT_INVENTORY };
   private interactionHint!: Phaser.GameObjects.Text;
   private buildMode = false;
   private selectedBuildPiece: BuildPieceId = 'woodFloor';
@@ -148,6 +169,8 @@ export class WorldScene extends Phaser.Scene {
   private buildGhostLabel!: Phaser.GameObjects.Text;
   private buildGhostPulse?: Phaser.GameObjects.Arc;
   private placedPieces: PlacedBuildPiece[] = [];
+  private hudVisible = true;
+  private resetArmedUntil = 0;
 
   constructor() {
     super('WorldScene');
@@ -167,16 +190,19 @@ export class WorldScene extends Phaser.Scene {
     this.cameras.main.setZoom(1.15);
 
     this.cursors = this.input.keyboard!.createCursorKeys();
-    this.keys = this.input.keyboard!.addKeys('W,A,S,D,E,B,X,ESC,ONE,TWO,THREE,FOUR,FIVE,SIX') as InputKeys;
+    this.keys = this.input.keyboard!.addKeys('W,A,S,D,E,B,X,H,J,K,R,ESC,ONE,TWO,THREE,FOUR,FIVE,SIX') as InputKeys;
 
     this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => this.handlePointerDown(pointer));
+    this.loadGame(false);
     this.emitInventoryChanged();
     this.emitBuildChanged();
+    this.emitHudVisibilityChanged();
   }
 
   update(_: number, delta: number): void {
     this.updatePlayerMovement(delta);
     this.updateBuildInput();
+    this.updateMetaInput();
 
     if (Phaser.Input.Keyboard.JustDown(this.keys.E) && !this.buildMode) {
       this.harvestNearestResource();
@@ -432,6 +458,7 @@ export class WorldScene extends Phaser.Scene {
 
     this.emitInventoryChanged();
     this.showHarvestFeedback(node, amount);
+    this.saveGame(false);
 
     if (node.health <= 0) {
       this.destroyResource(node);
@@ -464,6 +491,7 @@ export class WorldScene extends Phaser.Scene {
     this.emitInventoryChanged();
     this.showFloatingText(snapped.x, snapped.y - 48, `${piece.label} placed`, '#42f59b');
     this.cameras.main.flash(85, 244, 209, 138, false);
+    this.saveGame(false);
   }
 
   private createBuildPieceVisual(pieceId: BuildPieceId, x: number, y: number, ghost: boolean): Phaser.GameObjects.Container {
@@ -685,6 +713,7 @@ export class WorldScene extends Phaser.Scene {
     });
 
     this.cameras.main.shake(60, 0.0011);
+    this.saveGame(false);
   }
 
   private findPlacedPieceAt(x: number, y: number): PlacedBuildPiece | undefined {
@@ -791,6 +820,14 @@ export class WorldScene extends Phaser.Scene {
     });
   }
 
+  private emitHudVisibilityChanged(): void {
+    this.game.events.emit('hud:visibility-changed', this.hudVisible);
+  }
+
+  private showHudFeedback(message: string, color = '#f4d18a'): void {
+    this.game.events.emit('hud:feedback', { message, color });
+  }
+
   private showFloatingText(x: number, y: number, message: string, color: string): void {
     const text = this.add.text(x, y, message, {
       fontFamily: 'monospace',
@@ -857,5 +894,119 @@ export class WorldScene extends Phaser.Scene {
     }
 
     this.cameras.main.shake(75, 0.0012);
+  }
+
+  private updateMetaInput(): void {
+    if (Phaser.Input.Keyboard.JustDown(this.keys.J)) {
+      this.saveGame(true);
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.keys.K)) {
+      this.loadGame(true);
+      this.emitInventoryChanged();
+      this.emitBuildChanged();
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.keys.H)) {
+      this.hudVisible = !this.hudVisible;
+      this.emitHudVisibilityChanged();
+      this.showHudFeedback(this.hudVisible ? 'HUD shown' : 'HUD hidden for screenshot', '#8bd3ff');
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.keys.R)) {
+      if (this.time.now < this.resetArmedUntil) {
+        this.resetSave();
+        this.resetArmedUntil = 0;
+      } else {
+        this.resetArmedUntil = this.time.now + RESET_CONFIRM_WINDOW_MS;
+        this.showHudFeedback('Press R again in 3s to reset save', '#ff9a7a');
+      }
+    }
+  }
+
+  private saveGame(manual: boolean): void {
+    const saveData: SaveData = {
+      version: 1,
+      inventory: { ...this.inventory },
+      placedPieces: this.placedPieces.map((piece) => ({
+        pieceId: piece.pieceId,
+        gridX: piece.gridX,
+        gridY: piece.gridY
+      })),
+      savedAt: new Date().toISOString()
+    };
+
+    try {
+      window.localStorage.setItem(SAVE_STORAGE_KEY, JSON.stringify(saveData));
+      if (manual) {
+        this.showHudFeedback('Game saved', '#42f59b');
+      }
+    } catch {
+      this.showHudFeedback('Save failed (storage unavailable)', '#ff7f60');
+    }
+  }
+
+  private loadGame(manual: boolean): void {
+    const rawSave = window.localStorage.getItem(SAVE_STORAGE_KEY);
+    if (!rawSave) {
+      if (manual) {
+        this.showHudFeedback('No save found', '#ff9a7a');
+      }
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(rawSave) as SaveData;
+      if (parsed.version !== 1) {
+        this.showHudFeedback('Save version mismatch', '#ff7f60');
+        return;
+      }
+
+      this.inventory = {
+        wood: Math.max(0, parsed.inventory.wood ?? 0),
+        stone: Math.max(0, parsed.inventory.stone ?? 0),
+        ironOre: Math.max(0, parsed.inventory.ironOre ?? 0),
+        resin: Math.max(0, parsed.inventory.resin ?? 0)
+      };
+      this.restorePlacedPieces(parsed.placedPieces);
+
+      if (manual) {
+        this.showHudFeedback('Game loaded', '#8bd3ff');
+      }
+    } catch {
+      this.showHudFeedback('Load failed (corrupt save)', '#ff7f60');
+    }
+  }
+
+  private restorePlacedPieces(savedPieces: SavedPlacedPiece[]): void {
+    this.placedPieces.forEach((piece) => piece.container.destroy());
+    this.placedPieces = [];
+
+    savedPieces.forEach((savedPiece, index) => {
+      const container = this.createBuildPieceVisual(savedPiece.pieceId, savedPiece.gridX, savedPiece.gridY, false);
+      const placedPiece: PlacedBuildPiece = {
+        id: `${savedPiece.pieceId}_${savedPiece.gridX}_${savedPiece.gridY}_${index}`,
+        pieceId: savedPiece.pieceId,
+        gridX: savedPiece.gridX,
+        gridY: savedPiece.gridY,
+        container
+      };
+
+      const flame = placedPiece.container.getByName('torch_flame') as Phaser.GameObjects.Triangle | null;
+      if (flame) {
+        placedPiece.flame = flame;
+      }
+
+      this.placedPieces.push(placedPiece);
+    });
+  }
+
+  private resetSave(): void {
+    window.localStorage.removeItem(SAVE_STORAGE_KEY);
+    this.inventory = { ...DEFAULT_INVENTORY };
+    this.restorePlacedPieces([]);
+    this.showHudFeedback('Save reset', '#ff9a7a');
+    this.emitInventoryChanged();
+    this.emitBuildChanged();
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a local save/load system so players keep inventory and placed buildings between sessions using `localStorage` for Stage 3 acceptance criteria.  
- Ensure world visual state (torch flicker and roof fade interior reveal) is restored after load for screenshot-ready moments.  
- Add safe reset, autosave on key actions, and a HUD hide/feedback flow to support screenshot/GIF-ready workflows.

### Description
- Added a typed local save model `SaveData` and `SavedPlacedPiece` with `version`, `inventory`, `placedPieces`, and `savedAt`, persisted under the key `fjordhold_stage3_save` and handled by `saveGame` / `loadGame` / `resetSave` in `src/game/scenes/WorldScene.ts`.  
- Autosave is triggered after harvesting, placing a build piece, and deleting a build piece by calling `saveGame(false)`.  
- Restoring placed pieces is implemented via `restorePlacedPieces` which rebuilds visuals and re-links torch flame objects so flicker and `thatchRoof` interior reveal continue after load.  
- Added manual meta controls: `J` = save, `K` = load, `R` = safe reset (double-press within 3s), and `H` = toggle HUD visibility for screenshots, plus HUD feedback events (`hud:feedback`, `hud:visibility-changed`) and visible control hints in `src/game/scenes/UIScene.ts`.  
- Introduced `DEFAULT_INVENTORY`, a stable initial inventory, and a small safe-reset flow that restores defaults and clears the stored save on reset.

### Testing
- Ran `npm run build`, which runs `tsc --noEmit` and `vite build`, and the build completed successfully.  
- TypeScript compile checks passed as part of the build step.  
- No automated runtime/browser screenshot tests were available in this environment, so runtime validation (load/restore visuals and in-browser screenshot capture) should be verified in a browser session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed80deb870832fa93d4d199ac71b0f)